### PR TITLE
Add search bar to Instructor Sessions Page

### DIFF
--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -91,7 +91,8 @@ public abstract class Action {
      */
     public void checkAccessControl() throws UnauthorizedAccessException {
         String userParam = getRequestParamValue(Const.ParamsNames.USER_ID);
-        if (userInfo != null && userParam != null && !userInfo.isAdmin && !userInfo.id.equals(userParam)) {
+        if (userInfo != null && userParam != null && !userInfo.isAdmin
+                && !userInfo.id.replaceFirst("@gmail.com$", "").equals(userParam.replaceFirst("@gmail.com$", ""))) {
             throw new UnauthorizedAccessException("User " + userInfo.id
                     + " is trying to masquerade as " + userParam + " without admin permission.");
         }

--- a/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
@@ -84,7 +84,8 @@ abstract class BasicFeedbackSubmissionAction extends Action {
                 if (userInfo == null) {
                     // Student is associated to a google ID; even if registration key is passed, do not allow access
                     throw new UnauthorizedAccessException("Login is required to access this feedback session");
-                } else if (!userInfo.id.equals(student.getGoogleId())) {
+                } else if (!userInfo.id.replaceFirst("@gmail.com$", "")
+                        .equals(student.getGoogleId().replaceFirst("@gmail.com$", ""))) {
                     // Logged in student is not the same as the student registered for the given key, do not allow access
                     throw new UnauthorizedAccessException("You are not authorized to access this feedback session");
                 }
@@ -134,7 +135,8 @@ abstract class BasicFeedbackSubmissionAction extends Action {
                 if (userInfo == null) {
                     // Instructor is associated to a google ID; even if registration key is passed, do not allow access
                     throw new UnauthorizedAccessException("Login is required to access this feedback session");
-                } else if (!userInfo.id.equals(instructor.getGoogleId())) {
+                } else if (!userInfo.id.replaceFirst("@gmail.com$", "")
+                        .equals(instructor.getGoogleId().replaceFirst("@gmail.com$", ""))) {
                     // Logged in instructor is not the same as the instructor registered for the given key,
                     // do not allow access
                     throw new UnauthorizedAccessException("You are not authorized to access this feedback session");

--- a/src/main/java/teammates/ui/webapi/DeleteStudentProfilePictureAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentProfilePictureAction.java
@@ -18,7 +18,7 @@ class DeleteStudentProfilePictureAction extends Action {
             throw new UnauthorizedAccessException("Student privilege is required to update this resource.");
         }
         String googleId = getNonNullRequestParamValue(Const.ParamsNames.STUDENT_ID);
-        if (!userInfo.id.equals(googleId)) {
+        if (!userInfo.id.replaceFirst("@gmail.com$", "").equals(googleId.replaceFirst("@gmail.com$", ""))) {
             throw new UnauthorizedAccessException("You are not authorized to delete this student's profile.");
         }
     }

--- a/src/main/java/teammates/ui/webapi/GetRegkeyValidityAction.java
+++ b/src/main/java/teammates/ui/webapi/GetRegkeyValidityAction.java
@@ -57,7 +57,8 @@ class GetRegkeyValidityAction extends Action {
                 isUsed = true;
                 // If the registration key has been used to register, the logged in user needs to match
                 // Block access to not logged in user and mismatched user
-                isAllowedAccess = userInfo != null && googleId.equals(userInfo.id);
+                isAllowedAccess = userInfo != null && googleId.replaceFirst("@gmail.com$", "")
+                        .equals(userInfo.id.replaceFirst("@gmail.com$", ""));
             }
         }
 

--- a/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
+++ b/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
@@ -13,6 +13,7 @@ exports[`SessionsTableComponent should snap like in home page with 2 sessions so
   courseCandidates={[Function Array]}
   downloadSessionResultsEvent={[Function EventEmitter_]}
   headerColorScheme="0"
+  isSearchView="false"
   isSendReminderLoading="false"
   loadResponseRateEvent={[Function EventEmitter_]}
   moveSessionToRecycleBinEvent={[Function EventEmitter_]}
@@ -492,6 +493,7 @@ exports[`SessionsTableComponent should snap like in sessions page with 2 session
   courseCandidates={[Function Array]}
   downloadSessionResultsEvent={[Function EventEmitter_]}
   headerColorScheme="0"
+  isSearchView="false"
   isSendReminderLoading="false"
   loadResponseRateEvent={[Function EventEmitter_]}
   moveSessionToRecycleBinEvent={[Function EventEmitter_]}
@@ -942,6 +944,7 @@ exports[`SessionsTableComponent should snap with default fields 1`] = `
   courseCandidates={[Function Array]}
   downloadSessionResultsEvent={[Function EventEmitter_]}
   headerColorScheme="0"
+  isSearchView="false"
   isSendReminderLoading="false"
   loadResponseRateEvent={[Function EventEmitter_]}
   moveSessionToRecycleBinEvent={[Function EventEmitter_]}

--- a/src/web/app/components/sessions-table/sessions-table.component.html
+++ b/src/web/app/components/sessions-table/sessions-table.component.html
@@ -132,7 +132,10 @@
 </div>
 
 <ng-template #noSessionMessage>
-  <div class="no-session-message">
+  <div *ngIf="!isSearchView" class="no-session-message">
     There are no feedback sessions in this course.
+  </div>
+  <div *ngIf="isSearchView" class="no-session-message">
+    No search results found.
   </div>
 </ng-template>

--- a/src/web/app/components/sessions-table/sessions-table.component.ts
+++ b/src/web/app/components/sessions-table/sessions-table.component.ts
@@ -35,6 +35,9 @@ export class SessionsTableComponent {
   rowClicked: number = -1;
 
   @Input()
+  isSearchView: boolean = false;
+
+  @Input()
   sessionsTableRowModels: SessionsTableRowModel[] = [];
 
   @Input()

--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.html
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.html
@@ -23,11 +23,20 @@
                   (retryEvent)="retryLoadingAllData()">
   <div class="margin-top-30px">
     <div *tmIsLoading="isCoursesLoading || isMoveToRecycleBinLoading || isCopySessionLoading || isResultActionLoading">
-      <div class="alert alert-warning margin-top-30px" role="alert" *ngIf="sessionsTableRowModels.length === 0 && !isFeedbackSessionsLoading">
+      <div class="alert alert-warning margin-top-30px" role="alert" *ngIf="sessionsTableRowModels.length === 0 && !isFeedbackSessionsLoading && !isSearchView">
         You have not created any sessions yet. Use the form above to create a session.
       </div>
+      <div class="row">
+        <div class="col-12 text-muted">
+          <p>
+            Search for keywords in the course ID or session name:
+          </p>
+        </div>
+      </div>
+      <tm-sessions-search-bar (searched)="search()" (clearSearchPress)="clearSearch()" [(searchParams)]="searchParams" [isSearchView]="isSearchView"></tm-sessions-search-bar>
       <tm-sessions-table *tmIsLoading="isFeedbackSessionsLoading"
-                         [sessionsTableRowModels]="sessionsTableRowModels" [sessionsTableRowModelsSortBy]="sessionsTableRowModelsSortBy" [sessionsTableRowModelsSortOrder]="sessionsTableRowModelsSortOrder"
+                         [isSearchView]="isSearchView"
+                         [sessionsTableRowModels]="isSearchView ? searchedSessionsTableRowModels : sessionsTableRowModels" [sessionsTableRowModelsSortBy]="sessionsTableRowModelsSortBy" [sessionsTableRowModelsSortOrder]="sessionsTableRowModelsSortOrder"
                          [courseCandidates]="courseCandidates" [columnsToShow]="[ SessionsTableColumn.COURSE_ID ]"
                          [headerColorScheme]="SessionsTableHeaderColorScheme.BLUE"
                          [isSendReminderLoading]="isSendReminderLoading"
@@ -37,9 +46,9 @@
                          (submitSessionAsInstructorEvent)="submitSessionAsInstructorEventHandler($event)"
                          (publishSessionEvent)="publishSessionEventHandler($event)" (unpublishSessionEvent)="unpublishSessionEventHandler($event)"
                          (downloadSessionResultsEvent)="downloadSessionResultEventHandler($event)"
-                         (resendResultsLinkToStudentsEvent)="resendResultsLinkToRespondentsEventHandler(sessionsTableRowModels[$event])"
-                         (sendRemindersToAllNonSubmittersEvent)="sendRemindersToRespondentsEventHandler(sessionsTableRowModels[$event], true)"
-                         (sendRemindersToSelectedNonSubmittersEvent)="sendRemindersToRespondentsEventHandler(sessionsTableRowModels[$event], false)"></tm-sessions-table>
+                         (resendResultsLinkToStudentsEvent)="isSearchView ? resendResultsLinkToRespondentsEventHandler(searchedSessionsTableRowModels[$event]) : resendResultsLinkToRespondentsEventHandler(sessionsTableRowModels[$event])"
+                         (sendRemindersToAllNonSubmittersEvent)="isSearchView ? sendRemindersToRespondentsEventHandler(searchedSessionsTableRowModels[$event], true) : sendRemindersToRespondentsEventHandler(sessionsTableRowModels[$event], true)"
+                         (sendRemindersToSelectedNonSubmittersEvent)="isSearchView ? sendRemindersToRespondentsEventHandler(searchedSessionsTableRowModels[$event], false) : sendRemindersToRespondentsEventHandler(sessionsTableRowModels[$event], false)"></tm-sessions-table>
     </div>
   </div>
   <br/>

--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.module.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.module.ts
@@ -22,6 +22,7 @@ import {
 import {
   SessionsPermanentDeletionConfirmModalComponent,
 } from './sessions-permanent-deletion-confirm-modal/sessions-permanent-deletion-confirm-modal.component';
+import { SessionsSearchBarComponentModule } from './sessions-search-bar/sessions-search-bar-component.module';
 
 const routes: Routes = [
   {
@@ -45,6 +46,7 @@ const routes: Routes = [
     LoadingSpinnerModule,
     LoadingRetryModule,
     TeammatesRouterModule,
+    SessionsSearchBarComponentModule,
   ],
   declarations: [
     InstructorSessionsPageComponent,

--- a/src/web/app/pages-instructor/instructor-sessions-page/sessions-search-bar/sessions-search-bar-component.module.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/sessions-search-bar/sessions-search-bar-component.module.ts
@@ -1,0 +1,21 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { SessionsSearchBarComponent } from './sessions-search-bar.component';
+
+/**
+ * Module for different components used in instructor search page.
+ */
+@NgModule({
+  declarations: [
+    SessionsSearchBarComponent,
+  ],
+  exports: [
+    SessionsSearchBarComponent,
+  ],
+  imports: [
+    CommonModule,
+    FormsModule,
+  ],
+})
+export class SessionsSearchBarComponentModule { }

--- a/src/web/app/pages-instructor/instructor-sessions-page/sessions-search-bar/sessions-search-bar.component.html
+++ b/src/web/app/pages-instructor/instructor-sessions-page/sessions-search-bar/sessions-search-bar.component.html
@@ -1,0 +1,26 @@
+<div class="form-group">
+  <div class="input-group">
+    <input
+      type="text"
+      id="search-keyword"
+      class="form-control"
+      [ngModel]="searchParams.searchKey"
+      (ngModelChange)="onSearchKeyChange($event)"
+      (keyup.enter)="search()"
+      placeholder="Search for a course"
+    />
+    <div class="input-group-append">
+      <button
+        class="btn btn-primary"
+        id="btn-search"
+        (click)="search()"
+        [disabled]="searchParams.searchKey === ''"
+      >
+        Search
+      </button>
+      <button class="btn btn-secondary" (click)="clearSearch()" [disabled]="!isSearchView">
+        Clear Search
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/web/app/pages-instructor/instructor-sessions-page/sessions-search-bar/sessions-search-bar.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/sessions-search-bar/sessions-search-bar.component.spec.ts
@@ -1,0 +1,30 @@
+import { CommonModule } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { SessionsSearchBarComponent } from './sessions-search-bar.component';
+
+describe('SessionsSearchBarComponent', () => {
+  let component: SessionsSearchBarComponent;
+  let fixture: ComponentFixture<SessionsSearchBarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        FormsModule,
+      ],
+      declarations: [SessionsSearchBarComponent],
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SessionsSearchBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/pages-instructor/instructor-sessions-page/sessions-search-bar/sessions-search-bar.component.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/sessions-search-bar/sessions-search-bar.component.ts
@@ -1,0 +1,47 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+/**
+ * Parameters inputted by user to be used in search
+ */
+ export interface SearchParams {
+  searchKey: string;
+}
+
+@Component({
+  selector: 'tm-sessions-search-bar',
+  templateUrl: './sessions-search-bar.component.html',
+  styleUrls: ['./sessions-search-bar.component.scss'],
+})
+export class SessionsSearchBarComponent {
+
+  @Input() searchParams: SearchParams = {
+    searchKey: '',
+  };
+
+  @Input() isSearchView: boolean = false;
+
+  @Output() searched: EventEmitter<any> = new EventEmitter();
+
+  @Output() searchParamsChange: EventEmitter<SearchParams> = new EventEmitter();
+
+  @Output() clearSearchPress: EventEmitter<any> = new EventEmitter();
+
+    /**
+     * send the search data to parent for processing
+     */
+    search(): void {
+      this.searched.emit();
+    }
+
+    clearSearch(): void {
+      this.clearSearchPress.emit();
+    }
+
+    triggerSearchParamsChangeEvent(field: string, data: any): void {
+      this.searchParamsChange.emit({ ...this.searchParams, [field]: data });
+    }
+
+    onSearchKeyChange(newKey: string): void {
+      this.triggerSearchParamsChangeEvent('searchKey', newKey);
+    }
+}


### PR DESCRIPTION
Experimental feature which adds a search bar to assist instructors in finding the session they are looking for. This experimental feature is part of the IWM@NUS-OSS selection phase.

**Outline of Solution**
I created a new component, `SessionsSearchBar` for the Instructor Sessions Page. The search filters the sessions by checking if the Course ID or Session Name contains the search term. The other features, such as edit, delete, copy, view results, etc. have been modified slightly to work with the filtered table. Instructors can either press Enter or click 'Search'. When they want to reset to the original table, they can click the 'Clear Search' button.

Default:
![image](https://user-images.githubusercontent.com/61085398/183078202-55a4db60-6761-40e3-80c8-7f2bbf6b3001.png)

When search has been run:
![image](https://user-images.githubusercontent.com/61085398/183078262-9f775c2d-834f-42ee-8374-ac97362888f7.png)